### PR TITLE
#163048549 Endpoint to upvote a question to a specific meetup

### DIFF
--- a/app/api/v1/models/question_model.py
+++ b/app/api/v1/models/question_model.py
@@ -57,3 +57,30 @@ class QuestionModels(CommonModels):
         }
 
         return self.makeresp(resp, 201)
+
+
+    def upvote_question(self, question_id):
+        """ 
+        Increases the number of votes of a specific 
+        question by 1 
+        """
+
+        question = [[ind, question] for [ind, question] in enumerate(self.db) if question["id"] == question_id]
+
+        if not question:
+            return self.makeresp("Question not found", 404)
+
+        index = question[0][0]
+
+        votes = self.db[index]["votes"] + 1
+
+        self.db[index]["votes"] = votes
+
+        resp = {
+            "meetup": question[0][1]["meetup"],
+            "title": question[0][1]["title"],
+            "body": question[0][1]["body"],
+            "votes": question[0][1]["votes"]
+        }
+        
+        return self.makeresp(resp, 200)

--- a/app/api/v1/views/question_views.py
+++ b/app/api/v1/views/question_views.py
@@ -13,3 +13,11 @@ def create_question():
     resp = db.create_question(details)
 
     return jsonify(resp), resp["status"]
+
+@version1.route("/questions/<int:question_id>/upvote", methods=["PATCH"])
+def upvote_question(question_id):
+    """ Upvotes a specific question """
+
+    resp = db.upvote_question(question_id)
+
+    return jsonify(resp), resp["status"]

--- a/app/tests/v1/test_questions.py
+++ b/app/tests/v1/test_questions.py
@@ -64,6 +64,13 @@ class TestQuestions(unittest.TestCase):
 
         return response
 
+    def upvote_question(self, path="/api/v1/questions/<int:question_id>/upvote", data={}):
+        """ Increases votes of a specific question by 1 """
+        
+        response = self.client.patch(path)
+
+        return response
+
     def test_post_new_question(self):
         """ Tests whether new question is created with data provided """
 
@@ -72,7 +79,13 @@ class TestQuestions(unittest.TestCase):
         self.assertEqual(new_question.status_code, 201)
         self.assertTrue(new_question.json["data"])
 
-    
+    def test_upvote_question(self):
+        """ Tests for upvoting answer """
+
+        new_vote = self.post_question()
+
+        self.assertEqual(self.upvote_question(path="/api/v1/questions/{}/upvote".format(new_vote.json["data"][0]["id"])), 200)
+        self.assertTrue(self.upvote_question(path="/api/v1/questions/{}/upvote".format(new_vote.json["data"][0]["votes"])))
 
 
 if __name__ == "__main__":

--- a/app/tests/v1/test_questions.py
+++ b/app/tests/v1/test_questions.py
@@ -80,12 +80,14 @@ class TestQuestions(unittest.TestCase):
         self.assertTrue(new_question.json["data"])
 
     def test_upvote_question(self):
-        """ Tests for upvoting answer """
+        """ Tests for upvoting a question """
 
         new_vote = self.post_question()
+        self.assertEqual(new_vote.status_code, 201)
 
-        self.assertEqual(self.upvote_question(path="/api/v1/questions/{}/upvote".format(new_vote.json["data"][0]["id"])), 200)
-        self.assertTrue(self.upvote_question(path="/api/v1/questions/{}/upvote".format(new_vote.json["data"][0]["votes"])))
+        self.assertEqual(self.upvote_question(path="/api/v1/questions/{}/upvote".format(new_vote.json["data"][0]["user"])).status_code, 200)
+        self.assertTrue(self.upvote_question(path="/api/v1/questions/{}/upvote".format(new_vote.json["data"][0]["user"])).json["data"][0]["votes"])
+        self.assertEqual(self.upvote_question(path="/api/v1/questions/{}/upvote".format(new_vote.json["data"][0]["user"])).json["data"][0]["votes"], 3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What does this PR do ?
This pull request creates an endpoint that allows  a user to up-vote a question to a specific meetup

- Create an endpoint that allows a user to up-vote a question to a specific meetup 

- Use Postman to test for full functionality

### How should you manually test this?
*Step 1*
 
Navigate to your working directory, create and activate virtual environment 

```$ virtualenv venv```


```$ source venv/bin/activate```

Clone the repository 

```$ git clone https://github.com/Siffersari/Questioner.git```

Install project dependencies

```pip install -r requirements.txt```


*Step 2*
### Running the application
```$ flask run```

### Testing
```$ pytest app/api/tests/v1```

Equivalently, use Postman to test.


### Prerequisites

Pytest, Postman, Git,  Virtualenv


### What are the relevant PT stories?
[A registered user should be able to up-vote a question to a meetup](https://www.pivotaltracker.com/story/show/163048549)

### Screenshots

![screenshot from 2019-01-09 23-30-49](https://user-images.githubusercontent.com/33033576/50927334-7c88b880-1468-11e9-9d16-01cbf7e3d236.png)
![screenshot from 2019-01-09 23-30-56](https://user-images.githubusercontent.com/33033576/50927335-7eeb1280-1468-11e9-9e0f-f5731d02122d.png)






