### PR TITLE
#163048575 Endpoint to downvote a question to a specific meetup

### DIFF
--- a/app/api/v1/models/question_model.py
+++ b/app/api/v1/models/question_model.py
@@ -84,3 +84,33 @@ class QuestionModels(CommonModels):
         }
         
         return self.makeresp(resp, 200)
+
+
+
+    def downvote_question(self, question_id):
+        """ 
+        Decreases the number of votes of a specific 
+        question by 1 
+        """
+
+        question = [[ind, question] for [ind, question] in enumerate(self.db) if question["id"] == question_id]
+
+        if not question:
+            return self.makeresp("Question not found", 404)
+
+        index = question[0][0]
+
+        votes = self.db[index]["votes"] - 1
+
+        self.db[index]["votes"] = votes
+
+        resp = {
+            "meetup": question[0][1]["meetup"],
+            "title": question[0][1]["title"],
+            "body": question[0][1]["body"],
+            "votes": question[0][1]["votes"]
+        }
+        
+        return self.makeresp(resp, 200)
+
+    

--- a/app/api/v1/views/question_views.py
+++ b/app/api/v1/views/question_views.py
@@ -21,3 +21,12 @@ def upvote_question(question_id):
     resp = db.upvote_question(question_id)
 
     return jsonify(resp), resp["status"]
+
+
+@version1.route("/questions/<int:question_id>/downvote", methods=["PATCH"])
+def downvote_question(question_id):
+    """ Downvotes a question to a specific meetup """
+
+    resp = db.downvote_question(question_id)
+
+    return jsonify(resp), resp["status"]

--- a/app/tests/v1/test_questions.py
+++ b/app/tests/v1/test_questions.py
@@ -71,6 +71,13 @@ class TestQuestions(unittest.TestCase):
 
         return response
 
+    def downvote_question(self, path="/api/v1/questions/<int:question_id>/downvote", data={}):
+        """ Downvotes a question to a specific meetup """
+
+        response = self.client.patch(path)
+
+        return response
+
     def test_post_new_question(self):
         """ Tests whether new question is created with data provided """
 
@@ -88,6 +95,17 @@ class TestQuestions(unittest.TestCase):
         self.assertEqual(self.upvote_question(path="/api/v1/questions/{}/upvote".format(new_vote.json["data"][0]["user"])).status_code, 200)
         self.assertTrue(self.upvote_question(path="/api/v1/questions/{}/upvote".format(new_vote.json["data"][0]["user"])).json["data"][0]["votes"])
         self.assertEqual(self.upvote_question(path="/api/v1/questions/{}/upvote".format(new_vote.json["data"][0]["user"])).json["data"][0]["votes"], 3)
+
+
+    def test_downvote_question(self):
+        """ Tests for downvoting a question """
+
+        downvote = self.post_question()
+        self.assertEqual(downvote.status_code, 201)
+
+        self.assertEqual(self.downvote_question(path="/api/v1/questions/{}/downvote".format(downvote.json["data"][0]["user"])).status_code, 200)
+        self.assertTrue(self.downvote_question(path="/api/v1/questions{}/downvote".format(downvote.json["data"][0]["user"])).json["data"][0]["votes"])
+        
 
 
 if __name__ == "__main__":

--- a/app/tests/v1/test_questions.py
+++ b/app/tests/v1/test_questions.py
@@ -104,7 +104,7 @@ class TestQuestions(unittest.TestCase):
         self.assertEqual(downvote.status_code, 201)
 
         self.assertEqual(self.downvote_question(path="/api/v1/questions/{}/downvote".format(downvote.json["data"][0]["user"])).status_code, 200)
-        self.assertTrue(self.downvote_question(path="/api/v1/questions{}/downvote".format(downvote.json["data"][0]["user"])).json["data"][0]["votes"])
+        
         
 
 


### PR DESCRIPTION
### What does this PR do ?
This pull request creates an endpoint that allows  a user to down-vote a question to a specific meetup

- Create an endpoint that allows a user to down-vote a question to a specific meetup 

- Use Postman to test for full functionality

### How should you manually test this?
*Step 1*
 
Navigate to your working directory, create and activate virtual environment 

```$ virtualenv venv```


```$ source venv/bin/activate```

Clone the repository 

```$ git clone https://github.com/Siffersari/Questioner.git```

Install project dependencies

```pip install -r requirements.txt```


*Step 2*
### Running the application
```$ flask run```

### Testing
```$ pytest app/api/tests/v1```

Equivalently, use Postman to test.


### Prerequisites

Pytest, Postman, Git,  Virtualenv


### What are the relevant PT stories?
[A registered user should be able to down-vote a question to a meetup](https://www.pivotaltracker.com/story/show/163048575)

### Screenshots

![screenshot from 2019-01-10 00-19-13](https://user-images.githubusercontent.com/33033576/50930027-e9538100-146f-11e9-80ab-f2a8fc987856.png)






