### PR TITLE
#163047703 Endpoint to delete a specific meetup record

### DIFF
--- a/app/api/v2/models/meetup_model.py
+++ b/app/api/v2/models/meetup_model.py
@@ -125,3 +125,30 @@ class MeetupModels(BaseModels):
             resp.append(meetup)
 
         return self.makeresp(resp, 200)
+
+    def delete_meetup(self, meetup_id):
+        """ Accepts a meetup_id and deletes meetup record """
+        meetup = self.sql.fetch_details_by_id(
+            "meetup_id", meetup_id, "meetups")
+
+        if not meetup:
+            return self.makeresp("Meetup not found", 404)
+
+        user = self.sql.get_username_by_id(
+            int(self.meetup_details["user"]))
+
+        if not user:
+            return self.makeresp("This user is not found", 404)
+
+        is_admin = self.sql.get_admin_user(self.meetup_details["user"])
+
+        if self.check_is_error(is_admin):
+            status = 403
+            if 'Administrator' in is_admin:
+                status = 404
+
+            return self.makeresp(is_admin, status)
+
+        self.sql.delete_meetup(meetup_id)
+
+        return self.makeresp(["This meetup has been deleted successfully"], 200)

--- a/app/api/v2/utils/sql_helpers.py
+++ b/app/api/v2/utils/sql_helpers.py
@@ -154,6 +154,22 @@ class SqlHelper:
 
         return meetups
 
+    def delete_meetup(self, meetup_id):
+        """ Deletes a meetup record """
+
+        cur = self.database.cursor()
+
+        try:
+            cur.execute(
+                """ DELETE FROM meetups WHERE meetup_id = %d; """ % (meetup_id))
+
+            self.database.commit()
+
+        except:
+            return False
+
+        return "Meetup deleted successfully"
+
     def check_user_exist_by_email(self, email):
         """ Checks database for existing users using user emails """
 

--- a/app/api/v2/views/meetup_views.py
+++ b/app/api/v2/views/meetup_views.py
@@ -86,3 +86,38 @@ def fetch_upcoming_meetup():
         ), 400
 
     return jsonify(MeetupModels().fetch_upcoming_meetups()), MeetupModels().fetch_upcoming_meetups()["status"]
+
+
+@version2.route("/meetups/<int:meetup_id>", methods=['DELETE'])
+def delete_meetup(meetup_id):
+    """ Deletes a meetup record """
+    header = request.headers.get("Authorization")
+
+    if not header:
+        return jsonify(
+            {"error": "This resource is secured. Please provide authorization header",
+             "status": 400}
+        ), 400
+
+    auth_token = header.split(" ")[1]
+
+    response = MeetupModels().validate_token_status(auth_token)
+
+    if isinstance(response, str):
+        return jsonify(
+            {"error": response,
+             "status": 400}
+        ), 400
+
+    details = request.get_json()
+
+    try:
+        if not isinstance(details["user"], int):
+            return jsonify({"error": "user must an integer", "status": 400}), 400
+
+    except KeyError as keyerr:
+        return jsonify({"error": "{} is  a required key".format(keyerr), "status": 400}), 400
+
+    response = MeetupModels(details).delete_meetup(meetup_id)
+
+    return jsonify(response), response["status"]

--- a/app/tests/v2/test_meetups.py
+++ b/app/tests/v2/test_meetups.py
@@ -90,6 +90,19 @@ class TestMeetups(unittest.TestCase):
 
         return response
 
+    def delete_meetup(self, path="api/v2/meetups/<meetup-id>", data={}):
+        """ Deletes a meetup """
+
+        if not data:
+            data = {
+                "user": 1
+            }
+
+        response = self.client.delete(path, data=json.dumps(
+            data), content_type=self.content_type, headers=self.headers)
+
+        return response
+
     def fetch_specific_meetup(self, path="/api/v2/meetups/<meetup-id>"):
         """ Fetches a specific meetup record """
 
@@ -104,7 +117,7 @@ class TestMeetups(unittest.TestCase):
         return response
 
     def test_create_new_meetup(self):
-        """ Test cases for login in a user """
+        """ Test cases for creating  a new meetup """
 
         new_meetup = self.create_meetup()
 
@@ -161,6 +174,22 @@ class TestMeetups(unittest.TestCase):
             path="/api/v2/meetups/upcoming").json["data"])
         self.assertNotEqual(self.fetch_upcoming_meetup(
             path="/api/v2/meetups/upcoming").status_code, 404)
+
+    def test_delete_existing_meetup(self):
+        """ Test cases for login in a user """
+
+        new_meetup = self.create_meetup()
+
+        self.assertEqual(new_meetup.status_code, 201)
+
+        self.assertEqual(self.delete_meetup(
+            path="api/v2/meetups/1").status_code, 200)
+
+        self.assertEqual(self.delete_meetup(
+            path="api/v2/meetups/1").status_code, 404)
+
+        self.assertTrue(self.delete_meetup(
+            path="api/v2/meetups/1").json["error"])
 
     def tearDown(self):
         """ Destroys set up data before running each test """


### PR DESCRIPTION
### What does this PR do ?
This pull request creates an endpoint that allows  an administrator user to delete a meetup record

### Description of task to be completed?

- Create an endpoint that allows an administrator to delete a meetup record 

- Use Postman to test for full functionality

### How should you manually test this?
*Step 1*
 
Navigate to your working directory, create and activate virtual environment 

```$ virtualenv venv```


```$ source venv/bin/activate```

Clone the repository 

```$ git clone https://github.com/Siffersari/Questioner.git```

Install project dependencies

```pip install -r requirements.txt```


*Step 2*
### Running the application
```$ flask run```

### Testing
```$ pytest app/api/tests/v2```

Equivalently, use Postman to test.


### Prerequisites

Pytest, Postman, Git,  Virtualenv


### What are the relevant PT stories?
[An Admin user should be able to delete a meetup](https://www.pivotaltracker.com/story/show/163047703)

### Screenshots

![screenshot from 2019-01-19 11-14-53](https://user-images.githubusercontent.com/33033576/51424188-9ac68500-1bdb-11e9-9232-978977e898e7.png)

**Jwt authentication**

![screenshot from 2019-01-19 11-18-11](https://user-images.githubusercontent.com/33033576/51424321-16750180-1bdd-11e9-9948-dbd42d9bd43c.png)

**Validation**

![screenshot from 2019-01-19 11-14-58](https://user-images.githubusercontent.com/33033576/51424336-415f5580-1bdd-11e9-8d7b-907cd53cef98.png)


**Edge case Validation**
![screenshot from 2019-01-19 11-16-39](https://user-images.githubusercontent.com/33033576/51424364-9d29de80-1bdd-11e9-8f64-a5230c7bca5b.png)







