### PR TITLE
#163221099 Endpoint to add tags to a meetup record

### DIFF
--- a/app/api/v2/utils/sql_helpers.py
+++ b/app/api/v2/utils/sql_helpers.py
@@ -318,3 +318,44 @@ class SqlHelper:
         cur.close()
 
         return images
+
+    def get_tags(self, meetup_id):
+        """ Saves images to the database """
+
+        cur = self.database.cursor()
+
+        query = """ SELECT tags FROM meetups WHERE meetup_id = %d; """ % (
+            meetup_id)
+
+        cur.execute(query)
+
+        tags = cur.fetchone()[0]
+
+        cur.close()
+
+        if not tags:
+            return "Tags not found"
+
+        return tags
+
+    def add_tags(self, meetup_id):
+        """ Saves images to the database """
+
+        data = {
+            "tags": self.details["tags"],
+            "meetupId": meetup_id
+        }
+
+        cur = self.database.cursor()
+
+        query = """ UPDATE meetups SET tags = %(tags)s WHERE meetup_id = %(meetupId)s RETURNING images; """
+
+        cur.execute(query, data)
+
+        tags = cur.fetchone()[0]
+
+        self.database.commit()
+
+        cur.close()
+
+        return tags

--- a/app/api/v2/views/meetup_views.py
+++ b/app/api/v2/views/meetup_views.py
@@ -157,3 +157,39 @@ def post_images(meetup_id):
     response = MeetupModels(details).post_images(meetup_id)
 
     return jsonify(response), response["status"]
+
+
+@version2.route("/meetups/<int:meetup_id>/tags", methods=["POST"])
+def add_tags(meetup_id):
+    """ Add tags to a meetup """
+
+    header = request.headers.get("Authorization")
+
+    if not header:
+        return jsonify(
+            {"error": "This resource is secured. Please provide authorization header",
+             "status": 400}
+        ), 400
+
+    auth_token = header.split(" ")[1]
+
+    response = MeetupModels().validate_token_status(auth_token)
+
+    if isinstance(response, str):
+        return jsonify(
+            {"error": response,
+             "status": 400}
+        ), 400
+
+    details = request.get_json()
+
+    try:
+        if not isinstance(details["user"], int):
+            return jsonify({"error": "user must an integer", "status": 400}), 400
+
+    except KeyError as keyerr:
+        return jsonify({"error": "{} is  a required key".format(keyerr), "status": 400}), 400
+
+    response = MeetupModels(details).add_tags(meetup_id)
+
+    return jsonify(response), response["status"]

--- a/app/tests/v2/test_meetups.py
+++ b/app/tests/v2/test_meetups.py
@@ -117,6 +117,20 @@ class TestMeetups(unittest.TestCase):
 
         return response
 
+    def add_tags(self, path="api/v2/meetups/<meetup-id>/tags", data={}):
+        """ Adds images to meetup """
+
+        if not data:
+            data = {
+                "user": 1,
+                "tags": ["Instagram", "ruby"]
+            }
+
+        response = self.client.post(path, data=json.dumps(
+            data), content_type=self.content_type, headers=self.headers)
+
+        return response
+
     def fetch_specific_meetup(self, path="/api/v2/meetups/<meetup-id>"):
         """ Fetches a specific meetup record """
 
@@ -237,6 +251,39 @@ class TestMeetups(unittest.TestCase):
 
         self.assertEqual(self.post_images(
             path="/api/v2/meetups/1/images", data=data).status_code, 404)
+
+    def test_add_tags(self):
+        """ Tests for posting meetup """
+
+        new_meetup = self.create_meetup()
+
+        self.assertEqual(new_meetup.status_code, 201)
+
+        self.assertEqual(self.add_tags(
+            path="/api/v2/meetups/1/tags").status_code, 201)
+
+        self.assertTrue(self.add_tags(
+            path="/api/v2/meetups/1/tags").json["data"][0]["tags"])
+
+    def test_raises_Notfound_if_missing_meetup(self):
+        """ Tests for failure if missing meetup """
+
+        self.assertEqual(self.add_tags(
+            path="/api/v2/meetups/1/tags").status_code, 404)
+
+        self.assertTrue(self.add_tags(
+            path="/api/v2/meetups/1/tags").json["error"])
+
+    def test_raises_NotFound_if_missing_user(self):
+        """ Test for failure if missing user """
+
+        data = {
+            "user": 99,
+            "tags": ["tags"]
+        }
+
+        self.assertEqual(self.add_tags(
+            path="/api/v2/meetups/1/tags", data=data).status_code, 404)
 
     def tearDown(self):
         """ Destroys set up data before running each test """


### PR DESCRIPTION
### What does this PR do ?
This pull request creates an endpoint that allows  an Admin user to add tags to a specific meetup

### Description of task to be completed?

- Create an endpoint that allows an admin user to add tags to a specific meetup on Questioner

- Use Postman to test for full functionality

### How should you manually test this?
*Step 1*
 
Navigate to your working directory, create and activate virtual environment 

```$ virtualenv venv```


```$ source venv/bin/activate```

Clone the repository 

```$ git clone https://github.com/Siffersari/Questioner.git```

Install project dependencies

```pip install -r requirements.txt```


*Step 2*
### Running the application
```$ flask run```

### Testing
```$ pytest app/api/tests/v2```

Equivalently, use Postman to test.


### Prerequisites

Pytest, Postman, Git,  Virtualenv


### What are the relevant PT stories?
[An Admin user should be able to add tags to a meetup record](https://www.pivotaltracker.com/story/show/163221099)

### Screenshots
![screenshot from 2019-01-19 20-59-46](https://user-images.githubusercontent.com/33033576/51430703-fc184380-1c2f-11e9-8bdf-89bd85590731.png)

**Jwt authentication**

![screenshot from 2019-01-19 20-46-39](https://user-images.githubusercontent.com/33033576/51430710-09353280-1c30-11e9-94d4-689898c14773.png)

**Edge case Validation**
![screenshot from 2019-01-19 21-01-48](https://user-images.githubusercontent.com/33033576/51430720-1fdb8980-1c30-11e9-82d9-0df615e59574.png)








