### PR TITLE
#163396656 Endpoint to view a specific question to a meetup record

### DIFF
--- a/app/api/v2/models/question_model.py
+++ b/app/api/v2/models/question_model.py
@@ -200,3 +200,30 @@ class QuestionModels(BaseModels):
         }
 
         return self.makeresp(resp, 200)
+
+    def fetch_specific_question(self, question_id):
+        """ 
+        This methods takes in a question id and checks
+        if the question exists then returns it 
+        """
+
+        question = self.sql.fetch_details_by_id(
+            "question_id", question_id, "questions")
+
+        response, status = "", 200
+
+        if not question:
+
+            return self.makeresp("Question not found", 404)
+
+        user = self.sql.get_username_by_id(int(question[1]))
+
+        response = self.makeresp({
+
+            "user": user[0],
+            "meetup": question[2],
+            "title": question[3],
+            "body": question[4]
+        }, status)
+
+        return response

--- a/app/api/v2/views/question_views.py
+++ b/app/api/v2/views/question_views.py
@@ -90,3 +90,21 @@ def post_comment():
     resp = QuestionModels(details).post_comment()
 
     return make_response(jsonify(resp), resp["status"])
+
+
+@version2.route("/questions/<int:question_id>", methods=["GET"])
+def fetch_specific_question(question_id):
+    """
+    Fetches a question record given the question id 
+    """
+
+    check = QuestionModels().check_authorization()
+
+    if not check:
+
+        response = QuestionModels().fetch_specific_question(question_id)
+
+        return jsonify(response), response["status"]
+
+    else:
+        return check

--- a/app/tests/v2/test_questions.py
+++ b/app/tests/v2/test_questions.py
@@ -102,6 +102,13 @@ class TestQuestions(unittest.TestCase):
 
         return response
 
+    def fetch_specific_question(self, path="/api/v2/questions/<int:question-i>"):
+        """ Gets a specific question record using the question id """
+
+        response = self.client.get(path, headers=self.headers)
+
+        return response
+
     def create_comment(self, path="/api/v2/comments", data={}):
         """ Posts a comment to a question """
 
@@ -140,6 +147,31 @@ class TestQuestions(unittest.TestCase):
 
         self.assertEqual(new_question.status_code, 201)
         self.assertTrue(new_question.json["data"])
+
+    def test_fetch_specific_question(self):
+        """ Tests for successfull fetch of question if correct id """
+
+        new_question = self.post_question()
+
+        self.assertEqual(new_question.status_code, 201)
+
+        self.assertEqual(self.fetch_specific_question(
+            path="/api/v2/questions/1").status_code, 200)
+
+        self.assertTrue(self.fetch_specific_question(
+            path="/api/v2/questions/1").json["data"][0]["title"])
+
+        self.assertTrue(self.fetch_specific_question(
+            path="/api/v2/questions/1").json["data"][0]["body"])
+
+    def test_fails_to_fetch_returning_error_if_missing_id(self):
+        """ Tests for failure if nonexistent question id provided """
+
+        self.assertEqual(self.fetch_specific_question(
+            path="/api/v2/questions/1").status_code, 404)
+
+        self.assertTrue(self.fetch_specific_question(
+            path="/api/v2/questions/1").json["error"])
 
     def test_create_comment(self):
         """ Tests whether new question is created with data provided """


### PR DESCRIPTION
### What does this PR do ?
This pull request creates an endpoint that allows  a user to view a specific question to a meetup record on Questioner

- Create an endpoint that allows a user to view a specific meetup on the platform 
- Add tests for the endpoint

- Use Postman to test for full functionality

### How should you manually test this?
*Step 1*
 
Navigate to your working directory, create and activate virtual environment 

```$ virtualenv venv```


```$ source venv/bin/activate```

Clone the repository 

```$ git clone https://github.com/Siffersari/Questioner.git```

Install project dependencies

```pip install -r requirements.txt```


*Step 2*
### Running the application
```$ flask run```

### Testing
```$ pytest app/api/tests/v2```

Equivalently, use Postman to test.


### Prerequisites

Pytest, Postman, Git,  Virtualenv


### What are the relevant PT stories?
[163396656](https://www.pivotaltracker.com/story/show/163396656)

### Screenshots

**Success**
![screenshot from 2019-01-22 21-00-19](https://user-images.githubusercontent.com/33033576/51556605-b2c43000-1e8b-11e9-98b9-1c43afb7d0c0.png)

**Validation**
![screenshot from 2019-01-22 21-00-34](https://user-images.githubusercontent.com/33033576/51556599-b061d600-1e8b-11e9-9e4e-85910e349f62.png)

**JWT validation**
![screenshot from 2019-01-22 21-22-11](https://user-images.githubusercontent.com/33033576/51556646-d1c2c200-1e8b-11e9-923b-13c623c88017.png)








