### PR TITLE
#163397148 Endpoint to delete a comment to a question

### DIFF
--- a/app/api/v2/models/question_model.py
+++ b/app/api/v2/models/question_model.py
@@ -320,3 +320,23 @@ class QuestionModels(BaseModels):
         SqlHelper().delete_from_database(question_id, "questions")
 
         return self.makeresp({"message": "This question has been deleted successfully"}, 200)
+
+
+    def remove_comment(self, comment_id):
+
+        """ Removes a comment from the database """
+
+        comment = self.sql.fetch_details_by_id(
+            "comment_id", comment_id, "comments")
+
+        if not comment:
+
+            return self.makeresp("This comment could not be found", 404)
+
+        if not self.question_details["user"] == comment[1]:
+
+            return self.makeresp("You can not delete a comment you don't own", 403)
+
+        SqlHelper().delete_from_database(comment_id, "comments")
+
+        return self.makeresp({"message": "Comment deleted successfully"}, 200)

--- a/app/api/v2/views/question_views.py
+++ b/app/api/v2/views/question_views.py
@@ -75,11 +75,11 @@ def downvote_question(question_id):
 
         return QuestionModels().check_if_is_integer(details)
 
-    resp = jsonify(QuestionModels(details).downvote_question(question_id))
+    resp = QuestionModels(details).downvote_question(question_id)
 
-    status = QuestionModels(details).downvote_question(question_id)["status"]
+    status = resp["status"]
 
-    return resp, status
+    return jsonify(resp), status
 
 
 @version2.route("/comments", methods=["POST"])
@@ -159,7 +159,7 @@ def delete_question(question_id):
 
     if not request.get_json():
 
-        return jsonify({"error": "Expected data in JSON format but got none", "status": 400}, 400)
+        return jsonify({"error": "Expected data in JSON format but got none", "status": 400}), 400
 
     try:
 
@@ -167,8 +167,35 @@ def delete_question(question_id):
 
     except KeyError as erra:
 
-        return jsonify({"error": "Expected {} field but got none".format(erra), "status": 400}, 400)
+        return jsonify({"error": "Expected {} field but got none".format(erra), "status": 400}), 400
 
     response = QuestionModels(request.get_json()).delete_question(question_id)
 
     return jsonify(response), response["status"]
+
+
+@version2.route("/comments/<int:comment_id>", methods=['DELETE'])
+def delete_comment(comment_id):
+    """ Deletes a comment to a question if exists by Id """
+
+    if QuestionModels().check_authorization():
+
+        return QuestionModels().check_authorization()
+
+    data = request.get_json()
+
+    if not data:
+
+        return jsonify({"error": "Expected data in JSON format but got none", "status": 400}), 400
+
+    try:
+
+        user = request.get_json()["user"]
+
+    except KeyError as missing_erra:
+
+        return jsonify({"error": "Expected {} field but got none".format(missing_erra), "status": 400}), 400
+
+    result = QuestionModels(data).remove_comment(comment_id)
+
+    return jsonify(result), result["status"]

--- a/app/tests/v2/test_questions.py
+++ b/app/tests/v2/test_questions.py
@@ -168,6 +168,19 @@ class TestQuestions(unittest.TestCase):
 
         return response
 
+    def delete_comment(self, path="/api/v2/comments/<int:comment_id>", data={}):
+        """ Deletes a specific comment by ID """
+
+        if not data:
+            data = {
+                "user": 1
+            }
+
+        response = self.client.delete(path, data=json.dumps(
+            data), content_type=self.content_type, headers=self.headers)
+
+        return response
+
     def test_post_new_question(self):
         """ Tests whether new question is created with data provided """
 
@@ -296,6 +309,23 @@ class TestQuestions(unittest.TestCase):
 
         self.assertEqual(self.delete_question(
             path="/api/v2/questions/1").status_code, 404)
+
+    def test_delete_comment_if_owner_success(self):
+        """ Test for successful delete of comment by owner """
+
+        new_question = self.post_question()
+
+        self.assertEqual(new_question.status_code, 201)
+
+        new_comment = self.create_comment()
+
+        self.assertEqual(new_comment.status_code, 201)
+
+        self.assertEqual(self.delete_comment(
+            path="/api/v2/comments/1").status_code, 200)
+
+        self.assertEqual(self.delete_comment(
+            path="/api/v2/comments/1").status_code, 404)
 
     def tearDown(self):
         """ Destroys set up data before running each test """


### PR DESCRIPTION
### What does this PR do ?
This pull request creates an endpoint that allows  a user to delete a comment they own on Questioner
### Description of task to be completed?
- Create an endpoint that allows a user to delete a comment they own on the platform 
- Add tests for the endpoint

- Use Postman to test for full functionality

### How should you manually test this?
*Step 1*
 
Navigate to your working directory, create and activate virtual environment 

```$ virtualenv venv```


```$ source venv/bin/activate```

Clone the repository 

```$ git clone https://github.com/Siffersari/Questioner.git```

Install project dependencies

```pip install -r requirements.txt```


*Step 2*
### Running the application
```$ flask run```

### Testing
```$ pytest app/api/tests/v2```

Equivalently, use Postman to test.


### Prerequisites

Pytest, Postman, Git,  Virtualenv


### What are the relevant PT stories?
[163397148](https://www.pivotaltracker.com/story/show/163397148)

### Screenshots

**Success**

![screenshot from 2019-01-23 08-03-14](https://user-images.githubusercontent.com/33033576/51584780-d3ba6e80-1ee7-11e9-8329-026c128082f0.png)

**Validation**

![screenshot from 2019-01-23 08-21-51](https://user-images.githubusercontent.com/33033576/51584806-f5b3f100-1ee7-11e9-8f17-cfe0dd4bb764.png)


**JWT validation**
![screenshot from 2019-01-23 07-55-16](https://user-images.githubusercontent.com/33033576/51584817-095f5780-1ee8-11e9-88b5-0e1e8f7e2ef2.png)









