### PR TITLE
#163646954 Fix data passing for endpoint to fetch meetup id using details

### DIFF
--- a/app/api/v2/views/meetup_views.py
+++ b/app/api/v2/views/meetup_views.py
@@ -119,8 +119,8 @@ def add_tags(meetup_id):
     return jsonify(response), MeetupModels(details).add_tags(meetup_id)["status"]
 
 
-@version2.route("/meetups", methods=["GET"])
-def fetch_meetup_id():
+@version2.route("/meetups/<string:topic>/<string:location>", methods=["GET"])
+def fetch_meetup_id(topic, location):
     """ Fetches a meetup id given location and topic """
 
     decoded_auth = MeetupModels().check_authorization()
@@ -129,13 +129,11 @@ def fetch_meetup_id():
 
         return decoded_auth
 
-    try:
-        details = request.get_json()
-
-        details["user"] = decoded_auth
-
-    except:
-        return jsonify(MeetupModels().makeresp("Please provide a JSON object with a topic and location", 400)), 400
+    details = {
+        "topic": topic,
+        "location": location,
+        "user": decoded_auth
+    }
 
     response = MeetupModels(details).fetch_meetup_id_by_details()
 

--- a/app/tests/v2/base_test.py
+++ b/app/tests/v2/base_test.py
@@ -130,15 +130,11 @@ class BaseTest(unittest.TestCase):
 
         return response
 
-    def fetch_meetup_id(self, path="/api/v2/meetups", data={}):
+    def fetch_meetup_id(self, path="/api/v2/meetups/<topic>/<location>"):
         """ Fetches a specific meetup id given topic and location """
 
-        if not data:
-
-            data = self.fetch_meet_data
-
         response = self.client.get(
-            path, data=json.dumps(data), content_type=self.content_type, headers=self.get_token())
+            path, headers=self.get_token())
 
         return response
 

--- a/app/tests/v2/test_meetups.py
+++ b/app/tests/v2/test_meetups.py
@@ -49,18 +49,22 @@ class TestMeetups(BaseTest):
         self.assertEqual(meetup.status_code, 201)
         self.assertTrue(meetup.json["data"])
 
-        self.assertEqual(self.fetch_meetup_id().status_code, 200)
+        self.assertEqual(self.fetch_meetup_id(path="/api/v2/meetups/{}/{}".format(
+            self.meetup_data["topic"], self.meetup_data["location"])).status_code, 200)
 
-        self.assertTrue(self.fetch_meetup_id().json["data"][0]["id"] == 1)
+        self.assertTrue(self.fetch_meetup_id(path="/api/v2/meetups/{}/{}".format(
+            self.meetup_data["topic"], self.meetup_data["location"])).json["data"][0]["id"] == 1)
 
     def test_failure_if_non_existent_meetup(self):
         """
         Tests for failure if no meetup exists at all 
         """
 
-        self.assertEqual(self.fetch_meetup_id().status_code, 404)
+        self.assertEqual(self.fetch_meetup_id(path="/api/v2/meetups/{}/{}".format(
+            self.meetup_data["topic"], self.meetup_data["location"])).status_code, 404)
 
-        self.assertTrue("No meetup" in self.fetch_meetup_id().json["error"])
+        self.assertTrue("No meetup" in self.fetch_meetup_id(path="/api/v2/meetups/{}/{}".format(
+            self.meetup_data["topic"], self.meetup_data["location"])).json["error"])
 
     def test_failure_if_wrong_topic(self):
         """ 
@@ -73,11 +77,11 @@ class TestMeetups(BaseTest):
         self.assertEqual(meetup.status_code, 201)
         self.assertTrue(meetup.json["data"])
 
-        self.assertEqual(self.fetch_meetup_id(
-            data=self.wrong_meet_topic).status_code, 404)
+        self.assertEqual(self.fetch_meetup_id(path="/api/v2/meetups/{}/{}".format(
+            self.wrong_meet_topic["topic"], self.wrong_meet_topic["location"])).status_code, 404)
 
-        self.assertTrue("No meetup" in self.fetch_meetup_id(
-            data=self.wrong_meet_topic).json["error"])
+        self.assertTrue("No meetup" in self.fetch_meetup_id(path="/api/v2/meetups/{}/{}".format(
+            self.wrong_meet_topic["topic"], self.wrong_meet_topic["location"])).json["error"])
 
     def test_fetches_meetup_record_if_correct_id(self):
         """


### PR DESCRIPTION
### What does this PR do ?
This pull request fixes data passing for endpoint that allows  an admin user to fetch a meetup id using the meetup details

### Description of task to be completed?
- Move data being passed to the endpoint instead of being passed as a JSON object

- Restructure tests for the endpoint

- Use Postman to test for full functionality

### How should you manually test this?
*Step 1*
 
Navigate to your working directory, create and activate virtual environment 

```$ virtualenv venv```


```$ source venv/bin/activate```

Clone the repository 

```$ git clone https://github.com/Siffersari/Questioner.git```

Install project dependencies

```pip install -r requirements.txt```


*Step 2*
### Running the application
```$ flask run```

### Testing
```$ pytest app/api/tests/v2```

Equivalently, use Postman to test.


### Prerequisites

Pytest, Postman, Git,  Virtualenv


### What are the relevant PT stories?
[163646954](https://www.pivotaltracker.com/story/show/163646954)

### Screenshots

**Success**

![screenshot from 2019-02-01 12-45-54](https://user-images.githubusercontent.com/33033576/52115320-5dbcb280-261f-11e9-9495-e6f682b4d4f3.png)










